### PR TITLE
Allow running without OpenTripMap API key

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ pip install -r requirements.txt
 
 ## Collecting POI Data
 
-Use `scripts/collect_opentripmap.py` to fetch places around a location. You must supply your own OpenTripMap API key.
+Use `scripts/collect_opentripmap.py` to fetch places around a location. Supplying an OpenTripMap API key is optional. Without a key the script will simply copy the bundled sample data.
 
 Example usage:
 
@@ -26,6 +26,8 @@ python scripts/collect_opentripmap.py \
     --limit 50 \
     --output data/seoul_poi.csv
 ```
+
+Omit the `--apikey` flag to simply copy the included sample data instead of contacting the API.
 
 This command downloads up to 50 places within a 1 km radius of the coordinates provided (here: Seoul, South Korea) and saves them to `data/seoul_poi.csv`.
 


### PR DESCRIPTION
## Summary
- make OpenTripMap API key optional and fallback to example data
- update README to explain the new behaviour

## Testing
- `python -m py_compile scripts/collect_opentripmap.py scripts/tag_chatbot.py scripts/simple_rag_chatbot.py webapp.py`
- `python scripts/collect_opentripmap.py --output data/test.csv` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_6840e7c6eb30832b822094898417bbc8